### PR TITLE
Make client measure latency to the coordinator

### DIFF
--- a/typesocket/client.go
+++ b/typesocket/client.go
@@ -68,6 +68,7 @@ func (c *ClientConn) pongHandler(message string) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.latency = time.Now().Sub(c.lastPing)
+	log.WithFields(log.Fields{"latency": c.latency}).Info("updated latency")
 	return nil
 }
 

--- a/typesocket/client.go
+++ b/typesocket/client.go
@@ -14,8 +14,10 @@ import (
 )
 
 type ClientConn struct {
-	mu sync.Mutex
-	ws *websocket.Conn
+	mu       sync.Mutex
+	ws       *websocket.Conn
+	lastPing time.Time
+	latency  time.Duration
 }
 
 type Conn interface {
@@ -41,6 +43,9 @@ func Dial(addr string, peerKey ed25519.PublicKey) (*ClientConn, error) {
 
 	ws.SetReadDeadline(time.Now().Add(pongWait))
 	ws.SetPingHandler(conn.pingHandler)
+	ws.SetPongHandler(conn.pongHandler)
+
+	go conn.sendPingsLoop(pingPeriod)
 
 	return conn, nil
 }
@@ -57,12 +62,48 @@ func (c *ClientConn) pingHandler(message string) error {
 	return err
 }
 
+func (c *ClientConn) pongHandler(message string) error {
+	// If we hear back from the server, don't close the connection for another pongWait time.
+	c.ws.SetReadDeadline(time.Now().Add(pongWait))
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.latency = time.Now().Sub(c.lastPing)
+	return nil
+}
+
 func (c *ClientConn) Close() error {
 	c.mu.Lock()
 	c.ws.WriteMessage(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseGoingAway, ""))
 	c.mu.Unlock()
 
 	return c.ws.Close()
+}
+
+func (c *ClientConn) Latency() time.Duration {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.latency
+}
+
+func (c *ClientConn) sendPingsLoop(period time.Duration) {
+	ticker := time.NewTicker(period)
+	defer func() {
+		ticker.Stop()
+		c.ws.Close()
+	}()
+	for {
+		select {
+		case <-ticker.C:
+			c.mu.Lock()
+			c.lastPing = time.Now()
+			if err := c.ws.WriteControl(websocket.PingMessage, []byte{}, time.Now().Add(writeWait)); err != nil {
+				c.mu.Unlock()
+				log.Errorf("client: write (ping) error: %s", err)
+				return
+			}
+			c.mu.Unlock()
+		}
+	}
 }
 
 func (c *ClientConn) Send(msgID string, v interface{}) error {


### PR DESCRIPTION
Addresses https://github.com/vuvuzela/vuvuzela/issues/43. Depends on https://github.com/vuvuzela/internal/pull/1.

Client sends ping messages regularly and updates its value for latency every time it receives a pong.

Test has the client ping every 10ms, then check that latency is 0 after 10ms and >0 after ~15ms.